### PR TITLE
Release v0.2.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: make version
       run: |
-        export CI_BRANCH=${GITHUB_REF#refs/heads/}
         make version .env.docker
     - run: make ci-report
     - run: make build-docker-image
@@ -37,6 +36,7 @@ jobs:
     - name: make release-in-docker
       run: |
         if [[ "${GITHUB_REF#refs/heads/}" == "release" ]]; then
+          export CI_BRANCH=${GITHUB_REF#refs/heads/}
           export PACKAGECLOUD_REPOSITORY=dokku/dokku
           rm .env.docker
           make .env.docker release-in-docker release-packagecloud-in-docker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.2.2](https://github.com/dokku/go-netrc/compare/v0.2.1...v0.2.2) - 2021-02-20
+
+### Fixes
+
+- @josegonzalez Set CI_BRANCH correctly for release process
+
 ## [0.2.1](https://github.com/dokku/go-netrc/compare/v0.2.0...v0.2.1) - 2021-02-20
 
 ### Changes

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ MAINTAINER_NAME = Jose Diaz-Gonzalez
 REPOSITORY = go-netrc
 HARDWARE = $(shell uname -m)
 SYSTEM_NAME  = $(shell uname -s | tr '[:upper:]' '[:lower:]')
-BASE_VERSION ?= 0.2.1
+BASE_VERSION ?= 0.2.2
 IMAGE_NAME ?= $(MAINTAINER)/$(REPOSITORY)
 PACKAGECLOUD_REPOSITORY ?= dokku/dokku-betafish
 


### PR DESCRIPTION
## [0.2.2](https://github.com/dokku/go-netrc/compare/v0.2.1...v0.2.2) - 2021-02-20

### Fixes

- @josegonzalez Set CI_BRANCH correctly for release process
